### PR TITLE
Use FQCN and fix deprecated include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,24 @@
 ---
 # tasks file for duckdns
 
-# Add the user with a primary group
-- group:
+- name: "Add the {{ duckdns_group }} group"
+  ansible.builtin.group:
     name: "{{ duckdns_group }}"
     state: present
 
-- user:
+- name: "Add the {{ duckdns_user }} user"
+  ansible.builtin.user:
     name: "{{ duckdns_user }}"
     comment: "duckdns user"
     group: "{{ duckdns_group }}"
     state: present
 
 - name: Install require packages
-  include: ubuntu_packages.yml
+  ansible.builtin.include_tasks: ubuntu_packages.yml
   when: ansible_distribution == "Ubuntu"
 
 - name: Ensures required directories exists
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: "directory"
   with_items:
@@ -25,15 +26,16 @@
       - "{{ duckdns_project_log }}"
 
 - name: Setup cron executable
-  template:
+  ansible.builtin.template:
     src: "templates/duck.sh"
     dest: "{{ duckdns_project_root }}/duck.sh"
     owner: "{{ duckdns_user }}"
     group: "{{ duckdns_group }}"
     mode: 700
 
-# Creates a cron file under /etc/cron.d
-- cron:
+# 
+- name: "Create duck.sh cron file under /etc/cron.d"
+  ansible.builtin.cron:
     name: DuckDNS autoupdate
     special_time: hourly
     user: root
@@ -42,6 +44,6 @@
   notify: reload cron service
 
 - name: Update the IP Address Now
-  shell: "{{ duckdns_project_root }}/duck.sh"
+  ansible.builtin.shell: "{{ duckdns_project_root }}/duck.sh"
   changed_when: false
   when: duckdns_update_now

--- a/tasks/ubuntu_packages.yml
+++ b/tasks/ubuntu_packages.yml
@@ -1,8 +1,8 @@
 - name: Update repositories cache and install required packages
-  apt:
+  ansible.builtin.apt:
     pkg: "{{ item }}"
     state: latest
-  become: yes
+  become: True
   with_items:
     - cron
     - curl


### PR DESCRIPTION
Hi @rofrantz,

Some small changes to the role. The role was still using the now deprecated 'include'-task. Other tasks where using their old non-FQCN counter part. This PR fixes both, as well as some other small improvements. 
